### PR TITLE
login-bundle.js gets deleted when tests are run

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ If set to true then unsuffixed js assets (listed in the assets array) will be up
 </script>
 ```
 
+#### @param {options.requireLeadingSlash}
+- accepts: boolean
+- not required: defaults to false
+
+If set to true the asset matching is done by adding a leading forward slash to the pattern. This flag is useful if you use absolute paths and have assets with file names matching from the end, e.g. `toolbar.html` and `frame-toolbar.html`.
 
 ## Potential Gotchas
 - Assets that you want versioned must be listed in the assets array

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,6 +36,7 @@ var Version = function (opts) {
 
 		this.assets = opts.assets;
 		this.requireJs = opts.requireJs; // remove js suffix when replacing text in these files
+		this.requireLeadingSlash = opts.requireLeadingSlash;
         this.keepOriginalAndOldVersions = opts.keepOriginalAndOldVersions;
         this.keepOriginal = opts.keepOriginal;
         this.keepOldVersions = opts.keepOldVersions;
@@ -49,7 +50,8 @@ var Version = function (opts) {
 			keepOriginalAndOldVersions: this.keepOriginalAndOldVersions,
             keepOriginal: this.keepOriginal,
             keepOldVersions: this.keepOldVersions,
-			requireJs: this.requireJs
+			requireJs: this.requireJs,
+			requireLeadingSlash: this.requireLeadingSlash
 		};
 
 		return _(this).bindAll('run', 'initReplacers', 'checkPaths', 'grepFilesReplace', 'renameAssetsInFilesystem', 'deleteOldAssetsInFilesystem');

--- a/lib/replace-text.js
+++ b/lib/replace-text.js
@@ -40,6 +40,7 @@ var ReplaceText = function (opts) {
 	this.filePathBeg = removeSuffix(this.filePath);
 	this.filePathSuffix = returnSuffix(this.filePath);
 	this.requireJs = (opts.requireJs === true) && (this.filePathSuffix === '.js');
+	this.requireLeadingSlash = opts.requireLeadingSlash;
 
 	///////////////////////////////////////////////
 	// file NAME > for grepping > find + replace //
@@ -49,6 +50,10 @@ var ReplaceText = function (opts) {
 	this.fileNameSuffix = returnSuffix(this.fileName);
 	this.regedFileNameSuffix = escapeRegExp(this.fileNameSuffix);
 	this.regedFileNameBeg = escapeRegExp(this.fileNameBeg);
+
+	if (opts.requireLeadingSlash === true) {
+		this.regedFileNameBeg = '\\/' + this.regedFileNameBeg;
+	}
 
 	// regexes
 	this.oldVersionFileNameRegex = new RegExp(this.regedFileNameBeg + '\\.[a-z0-9]+' + this.regedFileNameSuffix + '$', "ig");
@@ -93,6 +98,9 @@ ReplaceText.prototype.assignNewVersion = function (callback) {
 ReplaceText.prototype.run = function (haystack, overrideRequireJs) {
 
 	var	newfileNameStem = this.fileNameBeg + '.' + this.newVersion;
+	if (this.requireLeadingSlash === true) {
+		newfileNameStem = '/' + newfileNameStem;
+	}
 
 	haystack = haystack.replace(this.fileNameRegex, newfileNameStem + this.fileNameSuffix);
 

--- a/test-utils/fixtures/js/bundle.js
+++ b/test-utils/fixtures/js/bundle.js
@@ -1,0 +1,1 @@
+var bundle = 'bundle';

--- a/test-utils/fixtures/js/login-bundle.js
+++ b/test-utils/fixtures/js/login-bundle.js
@@ -1,0 +1,1 @@
+var loginbundle = 'loginbundle';

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -166,3 +166,20 @@ test('Main.run(): md5 versioning', function(t) {
 		// fixtures dir = dif when run from this script (rather than npm run-script pretest)
 	}, fixturesDir);
 });
+
+test('Main.run(): matching file names', function(t) {
+	var mainInstance = new Main({
+		assets: [
+      jsDir + 'login-bundle.js',
+      jsDir + 'bundle.js'
+    ],
+    grepFiles: []
+	});
+
+	mainInstance.run(function() {
+		var jsDirContents = fs.readdirSync(jsDir);
+		t.ok(jsDirContents.indexOf(mainInstance.replacers[0].outputFileName) !== -1, mainInstance.replacers[0].outputFileName + " exists");
+		t.ok(jsDirContents.indexOf(mainInstance.replacers[1].outputFileName) !== -1, mainInstance.replacers[1].outputFileName + " exists");
+		t.end();
+	});
+});


### PR DESCRIPTION
In reference to techjacker/node-version-assets#8 - test fails because of login-bundle.versioned.js does not exist after running.